### PR TITLE
Fix nccl error for 70b

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,14 @@ sbatch convert.sbatch /capstor/scratch/cscs/asolergi/main_run_70B_megatron/Megat
 ```bash
 sbatch convert.sbatch /iopsstor/scratch/cscs/schlag/main_run_megatron/Megatron-LM/logs/Meg-Runs/main-runs-v1/apertus3-8b-128-nodes/checkpoints/ 1678000 /capstor/store/cscs/swissai/infra01/hf-checkpoints/Apertus8B-it1678000
 ```
+
+### NCCL error on large models
+
+If you are converting large models (for example 70B) and encountered NCCL errors, there is an option in `convert.sbatch` to disable the AWS OFI NCCL hook, which might resolves the error. Use the environment variable `AWS_OFF=1` to disable the AWS hook. This makes the script use `envs/env_aws_off.toml`.
+
+Examples:
+
+```bash
+export AWS_OFF=1
+sbatch convert.sbatch <ckpt-path> <iteration> <output-path>
+```

--- a/convert.sbatch
+++ b/convert.sbatch
@@ -33,6 +33,13 @@ TOKENIZER=${TOKENIZER:-alehc/swissai-tokenizer}
 MODEL=$1
 IT=$2
 OUT_PATH=$3
+AWS_OFF=${AWS_OFF:-0}
+
+if [ "$AWS_OFF" -eq 0 ]; then
+    ENV_FILE="env.toml"
+else
+    ENV_FILE="env_aws_off.toml"
+fi
 
 # Setup temporary paths.
 TEMP_PATH_ROOT=$SCRATCH/.tmp
@@ -45,7 +52,7 @@ trap cleanup EXIT
 MEGATRON_PATH="/workspace/Megatron-LM"
 
 echo "Running torchdist->torch"
-srun -ul --environment=./env.toml bash -c " \
+srun -ul --environment=./envs/$ENV_FILE bash -c " \
     cd ${MEGATRON_PATH}
     export PYTHONPATH=${MEGATRON_PATH}
     export CUDA_DEVICE_MAX_CONNECTIONS=1
@@ -59,7 +66,7 @@ srun -ul --environment=./env.toml bash -c " \
 "
 
 echo "Running torch->hf"
-srun -ul --environment=./env.toml bash -c " \
+srun -ul --environment=./envs/$ENV_FILE bash -c " \
     cd ${MEGATRON_PATH}
     export PYTHONPATH=${MEGATRON_PATH}
     python tools/checkpoint/convert.py \

--- a/envs/env.toml
+++ b/envs/env.toml
@@ -4,5 +4,5 @@ mounts = ["/capstor", "/iopsstor", "/users"]
 workdir = "/workspace"
 
 [annotations]
-com.hooks.aws_ofi_nccl.enabled = "true"
+com.hooks.aws_ofi_nccl.enabled = "false"
 com.hooks.aws_ofi_nccl.variant = "cuda12"

--- a/envs/env_aws_off.toml
+++ b/envs/env_aws_off.toml
@@ -1,0 +1,8 @@
+image = "/capstor/store/cscs/swissai/infra01/container-images/hfconverter-cuda.sqsh"
+
+mounts = ["/capstor", "/iopsstor", "/users"]
+workdir = "/workspace"
+
+[annotations]
+com.hooks.aws_ofi_nccl.enabled = "false"
+com.hooks.aws_ofi_nccl.variant = "cuda12"


### PR DESCRIPTION
Got NCCL error while converting 70b checkpoint:

`sbatch convert.sbatch /capstor/scratch/cscs/asolergi/main_run_70B_megatron/Megatron-LM/logs/Meg-Runs/main-runs-v1/apertus3-70b-512-nodes-1e-5lr/checkpoints-512-noOverlap 1062327 /iopsstor/scratch/cscs/ansaripo/hf_checkpoints/apertus70b_hf/iter_1062327`

Fixed by creating a new env and putting `com.hooks.aws_ofi_nccl.enabled` as `false`. Added as an option to `convert.sbatch` and updated the ReadMe accordingly.